### PR TITLE
Update composer plugin api requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "composer-plugin-api": "^1.0"
+        "composer-plugin-api": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/CleanupPlugin.php
+++ b/src/CleanupPlugin.php
@@ -35,7 +35,23 @@ class CleanupPlugin implements PluginInterface, EventSubscriberInterface
         $this->config = $composer->getConfig();
         $this->filesystem = new Filesystem();
         $this->rules = CleanupRules::getRules();
-    }
+	}
+	
+	/**
+     * {@inheritDoc}
+     */
+	public function deactivate(Composer $composer, IOInterface $io)
+	{
+		//
+	}
+
+	/**
+     * {@inheritDoc}
+     */
+	public function uninstall(Composer $composer, IOInterface $io)
+	{
+		//
+	}
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Due to the composer v2 release, the composer.json needs to be updated.

Releasing another version (0.3.0 ?) of the plugin should fix the error message.
I didn't any breaking changes in the [upgrading file](https://github.com/composer/composer/blob/2.0.0/UPGRADE-2.0.md) but maybe you could re-check before merging.

An issue is already open for this #26