### PR TITLE
Fix missing constants in ScriptEvents in composer v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,10 @@
     ],
     "require": {
         "composer-plugin-api": "^2.0"
-    },
+	},
+	"require-dev": {
+		"composer/composer": "^2.0"
+	},
     "autoload": {
         "psr-4": {
             "Barryvdh\\Composer\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "barryvdh/composer-cleanup-plugin",
+    "name": "kranack/composer-cleanup-plugin",
     "type": "composer-plugin",
     "description": "A composer cleanup plugin, to remove tests and documentation to save space",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "kranack/composer-cleanup-plugin",
+    "name": "barryvdh/composer-cleanup-plugin",
     "type": "composer-plugin",
     "description": "A composer cleanup plugin, to remove tests and documentation to save space",
     "license": "MIT",

--- a/src/CleanupPlugin.php
+++ b/src/CleanupPlugin.php
@@ -59,12 +59,8 @@ class CleanupPlugin implements PluginInterface, EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            ScriptEvents::POST_PACKAGE_INSTALL  => array(
-                array('onPostPackageInstall', 0)
-            ),
-            ScriptEvents::POST_PACKAGE_UPDATE  => array(
-                array('onPostPackageUpdate', 0)
-            ),
+			'post-package-install'	=> 'onPostPackageInstall',
+			'post-package-update'	=> 'onPostPackageUpdate',
             /*ScriptEvents::POST_INSTALL_CMD  => array(
                 array('onPostInstallUpdateCmd', 0)
             ),


### PR DESCRIPTION
- Composer v2 no longer uses constants in getSubscribedEvents method

This fix the error reported in #26 by @budziam